### PR TITLE
feat: soft remove Kewrnode

### DIFF
--- a/cosmoshub/lcd.json
+++ b/cosmoshub/lcd.json
@@ -217,6 +217,6 @@
     "name": "Kewr Node",
     "url": "https://rest-cosmos.kewrnode.com",
     "website": "https://kewrnode.com",
-    "weight": 1
+    "weight": 0
   }
 ]

--- a/cosmoshub/rpc.json
+++ b/cosmoshub/rpc.json
@@ -239,6 +239,6 @@
     "name": "Kewr Node",
     "url": "https://rpc-cosmos.kewrnode.com",
     "website": "https://kewrnode.com",
-    "weight": 1
+    "weight": 0
   }
 ]


### PR DESCRIPTION
The nodes maintained by Kewrnode have an incorrect network configuration. This PR fixes #17 by soft-removing these endpoints